### PR TITLE
Replaced sheadawson/silverstripe-linkable with gorriecoe/silverstripe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ TheWebmen\ElementalMaps\Model\ElementalMaps:
 ## Upgrading from v1.x to v2.x
 
 In v2.x `sheadawson/silverstripe-linkable` is replaced by `gorriecoe/silverstripe-linkfield`.
-
 When upgrading, you need to be aware of the fact that the links needs to get migrated.
+
+You may can use https://github.com/dynamic/silverstripe-link-migrator (as refer) to do this migration .

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # SilverStripe Elemental Maps
+For compatibility with sheadawson/silverstripe-linkable please use v1.x
 
 ## Description
-Google maps element for Elemental
+Google Maps element for Elemental
 
 ## Config
-Add the google maps API key:
+Add the Google Maps API key:
+
 ```yaml
 TheWebmen\ElementalMaps\Model\ElementalMaps:
   maps_api_key: 'API_KEY'
 ```
+## Upgrading from v1.x to v2.x
+
+In v2.x `sheadawson/silverstripe-linkable` is replaced by `gorriecoe/silverstripe-linkfield`.
+
+When upgrading, you need to be aware of the fact that the links needs to get migrated.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "silverstripe/cms": "^4.0@dev",
         "silverstripe/vendor-plugin": "^1.0",
         "thewebmen/silverstripe-addressfield": "^1.0",
-        "sheadawson/silverstripe-linkable": "^2.0"
+        "gorriecoe/silverstripe-linkfield": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Model/ElementalMapsMarker.php
+++ b/src/Model/ElementalMapsMarker.php
@@ -2,8 +2,8 @@
 
 namespace TheWebmen\ElementalMaps\Model;
 
-use Sheadawson\Linkable\Forms\LinkField;
-use Sheadawson\Linkable\Models\Link;
+use gorriecoe\LinkField\LinkField;
+use gorriecoe\Link\Models\Link;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
 use TheWebmen\Addressfield\Forms\GooglePlacesField;
@@ -41,7 +41,7 @@ class ElementalMapsMarker extends DataObject
         $googlePlacesField->setLatitudeField('Latitude');
         $googlePlacesField->setLongitudeField('Longitude');
 
-        $fields->addFieldToTab('Root.Main', new LinkField('LinkID'));
+        $fields->addFieldToTab('Root.Main', new LinkField('Link', 'Link', $this));
 
         return $fields;
     }

--- a/src/Model/ElementalMapsMarker.php
+++ b/src/Model/ElementalMapsMarker.php
@@ -33,6 +33,7 @@ class ElementalMapsMarker extends DataObject
         $fields = parent::getCMSFields();
 
         $fields->removeByName('ElementalMapsID');
+        $fields->removeByName('Link');
 
         $fields->addFieldToTab('Root.Main', new TextField('Title', 'Title'));
         $fields->addFieldToTab('Root.Main', $googlePlacesField = new GooglePlacesField('MapLocation', 'Map location'));


### PR DESCRIPTION
This PR replaces sheadawson/silverstripe-linkable with gorriecoe/silverstripe-linkable.
This because of the fact that sheadawson/silverstripe-linkable is not maintained anymore (and incompatible with SS4.11+).

Should be considered as API change, so I will release this in v2.0.0 release.

Test steps;
- [x] Create an grid page
- [x] Create an "Map" Grid element
- [x] Save it and create an marker (don't care if the Maps API is not working, because we only test the link field in here)
- [x] Save the maker and create an link for the marker
- [ ] Verify that the link is saved correctly

Right now I've not created an migration script for this change.

If its possible to create an separated migration script for this module with not-that-much effort, I will create a separate PR that can be released as v2.0.1 :smile: .