### PR TITLE
Option to add API key trough env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Add the Google Maps API key:
 TheWebmen\ElementalMaps\Model\ElementalMaps:
   maps_api_key: 'API_KEY'
 ```
+
+Or add the following variable to your `.env`:
+
+```
+WDVLP_ELEMENTAL_MAPS_API_KEY='API_KEY'
+```
+
 ## Upgrading from v1.x to v2.x
 
 In v2.x `sheadawson/silverstripe-linkable` is replaced by `gorriecoe/silverstripe-linkfield`.

--- a/src/Controller/ElementalMapsController.php
+++ b/src/Controller/ElementalMapsController.php
@@ -4,6 +4,7 @@ namespace TheWebmen\ElementalMaps\Controller;
 
 use DNADesign\Elemental\Controllers\ElementController;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Environment;
 use SilverStripe\View\Requirements;
 use TheWebmen\ElementalMaps\Model\ElementalMaps;
 
@@ -14,8 +15,20 @@ class ElementalMapsController extends ElementController {
         parent::init();
 
         $config = Config::forClass(ElementalMaps::class);
-        Requirements::javascript('https://maps.googleapis.com/maps/api/js?key=' . $config->get('maps_api_key'));
 
+        if ($config->get('maps_api_key')) {
+            $key = $config->get('maps_api_key');
+        }
+
+        if (empty($key) && Environment::getEnv('WDVLP_ELEMENTAL_MAPS_API_KEY')) {
+            $key = Environment::getEnv('WDVLP_ELEMENTAL_MAPS_API_KEY');
+        }
+
+        if (empty($key)) {
+            throw new \InvalidArgumentException("maps_api_key is empty", 1);
+        }
+
+        Requirements::javascript('https://maps.googleapis.com/maps/api/js?key=' . $key);
     }
 
 }


### PR DESCRIPTION
This PR adds an option to add an API key trough the `.env` variable.